### PR TITLE
Fix login redirect to patients tab

### DIFF
--- a/app/login.tsx
+++ b/app/login.tsx
@@ -66,7 +66,7 @@ export default function LoginScreen() {
             }
             if (email.trim() === settings.email && password === settings.password) {
                 Toast.show({ type: "success", text1: "Bem-vinda(o) de volta!" });
-                router.replace("./(tabs)/patients");
+                router.replace("/(tabs)/patients");
             } else {
                 Toast.show({ type: "error", text1: "E-mail ou senha inválidos.", position: "bottom" });
             }


### PR DESCRIPTION
## Summary
- update the login redirect to use the absolute tabs patients route so successful sign-in lands on the correct screen

## Testing
- npm run build:web

------
https://chatgpt.com/codex/tasks/task_e_68dec4587ab8832787193e8b0915d407