### PR TITLE
Wrap root layout with SafeAreaProvider

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -3,6 +3,7 @@ import { DarkTheme, DefaultTheme } from '@react-navigation/native';
 import { useFonts } from 'expo-font';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 import Toast from "react-native-toast-message";
 import { useTheme, ThemeProvider } from "../context/ThemeContext";
 
@@ -22,13 +23,14 @@ export default function RootLayout() {
   }
 
   return (
-    <ThemeProvider>
-      <Stack
-        screenOptions={{
-          headerShown: true,
-          headerStyle: { backgroundColor: theme.background },
-          headerTintColor: theme.primary,
-          headerTitleStyle: { fontWeight: "700" },
+    <SafeAreaProvider>
+      <ThemeProvider>
+        <Stack
+          screenOptions={{
+            headerShown: true,
+            headerStyle: { backgroundColor: theme.background },
+            headerTintColor: theme.primary,
+            headerTitleStyle: { fontWeight: "700" },
           headerShadowVisible: false,
           contentStyle: { backgroundColor: theme.surface },
         }}
@@ -71,10 +73,11 @@ export default function RootLayout() {
           }}
         />
 
-        <Stack.Screen name="+not-found" />
-      </Stack>
-      <StatusBar style="dark" backgroundColor={theme.background} />
-      <Toast />
-    </ThemeProvider>
+          <Stack.Screen name="+not-found" />
+        </Stack>
+        <StatusBar style="dark" backgroundColor={theme.background} />
+        <Toast />
+      </ThemeProvider>
+    </SafeAreaProvider>
   );
 }


### PR DESCRIPTION
## Summary
- wrap the root layout's ThemeProvider/Stack tree in SafeAreaProvider so safe-area hooks receive inset data

## Testing
- npx expo export -p web
- python -m http.server 4173 (serving dist) and curl -I http://127.0.0.1:4173/patient/index.html
- curl -I http://127.0.0.1:4173/schedule/index.html


------
https://chatgpt.com/codex/tasks/task_e_68dec44609548327999695dc1f296c03